### PR TITLE
asynchronous dataService examples

### DIFF
--- a/source/javascripts/dataController.js.coffee
+++ b/source/javascripts/dataController.js.coffee
@@ -4,7 +4,6 @@ angular.module "AnalysisFrontendApp.controllers"
         "$http"
         "$window"
         "dataService"
-        "instrumentService"
-        ($scope, $http, $window, dataService, instrumentService) ->
+        ($scope, $http, $window, dataService) ->
             dataService.fun($scope)
     ]

--- a/source/javascripts/dataService.js.coffee
+++ b/source/javascripts/dataService.js.coffee
@@ -5,27 +5,25 @@ angular.module "AnalysisFrontendApp.services"
         "instrumentService"
         ($http, $window, instrumentService) ->
             dataService = {}
-            getUser = () ->
-                user = ""
+            getUser = (arg) ->
                 $http.get "/api/user/findOne"
                     .success (data, status, headers, config) ->
-                        user = data
+                        arg.user = data
                     .error (data, status, headers, config) ->
                         if status is 403
                             delete $window.sessionStorage.token
-                user
-            getInstruments = () ->
-                instruments = {}
+
+            getInstruments = (arg) ->
                 instrumentService.get()
                     .success (data, status, headers, config) ->
-                        instruments = data
+                        arg.instruments = data
                     .error (data, status, headers, config) ->
                         if status is 403
                             delete $window.sessionStorage.token
-                instruments
 
             dataService.fun = (arg) ->
-                arg.user = getUser()
-                arg.instruments = getInstruments()
+                getUser arg
+                getInstruments arg
+
             dataService
     ]

--- a/source/views/quickview.html.haml
+++ b/source/views/quickview.html.haml
@@ -1,6 +1,6 @@
 %h1 Test
 
-%p Hello {{user.name}}
+%p Hello {{user.email}}
 
 -# %ul{"ng-repeat" => "robo in instruments"}
 


### PR DESCRIPTION
- the getUser and getInstrument examples must follow the asynchronous
  promise pattern
- the user attribute shown in the quickview is called email,
  user has no "name" attribute.
